### PR TITLE
nala: templates: Zero params for mock_ignore_in_once case

### DIFF
--- a/nala/templates/nala_mocks.c.jinja2
+++ b/nala/templates/nala_mocks.c.jinja2
@@ -435,6 +435,7 @@ int {{mock.func_name}}_mock_ignore_in_once({{mock.return_value_decl | render}})
 
     {{mock.state_name}}.state.mode = MODE_MOCK_ONCE;
     NALA_INSTANCE_NEW(instance_p, INSTANCE_MODE_NORMAL);
+    memset(&instance_p->data.parmas, 0, sizeof(instance_p->data.params));
     {% for param, _, _, _, _, _, check in mock.set_params %}
     nala_set_param_init(&instance_p->data.params.{{param.name}}_out);
     nala_set_param_init(&instance_p->data.params.{{param.name}}_in);


### PR DESCRIPTION
Otherwise when mocking for example a function that takes bool
UBSAN may print the following error:

    ./build-x86_64/unit-test-common/nala_mocks.c:67484:215: runtime error: load of value 190, which is not a valid value for type '_Bool'

Because params are never initialized to any value.